### PR TITLE
Add max-unit

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -1,22 +1,64 @@
 <!DOCTYPE html>
 <html ng-app="testApp">
     <head>
-        <link rel="stylesheet" type="text/css" media="screen" href="../bower_components/jquery-timepicker-jt/jquery.timepicker.css" />
+	<style type="text/css">
+		input{
+			max-width: 50px;
+		}
+	</style>
     </head>
     <body>
-        <div ng-controller="TimepickerCtrl">
+		<h1>Basic Example</h1>
+			<div data-ng-controller="TimepickerCtrl">
+			<p>
+				In its default state, this directive supports time units from seconds to years. Each unit of time is limited to its natural maximum
+				value (e.g. minutes must be on the interval [0-59]).
+			</p>
             <p>
-                <input momentduration="years" ng-model="duration"/>
-                <input momentduration="months" ng-model="duration"/>
-                <input momentduration="days" ng-model="duration"/>
-                <input momentduration="hours" ng-model="duration"/>
-                <input momentduration="minutes" ng-model="duration"/>
-                <input momentduration="seconds" ng-model="duration"/>
+                <label>Years:</label>&nbsp;<input data-momentduration="years" data-ng-model="duration"/>
+                <label>Months:</label>&nbsp;<input data-momentduration="months" data-ng-model="duration"/>
+                <label>Days:</label>&nbsp;<input data-momentduration="days" data-ng-model="duration"/>
+                <label>Hours:</label>&nbsp;<input data-momentduration="hours" data-ng-model="duration"/>
+                <label>Minutes:</label>&nbsp;<input data-momentduration="minutes" data-ng-model="duration"/>
+                <label>Seconds:</label>&nbsp;<input data-momentduration="seconds" data-ng-model="duration"/>
             </p>
+			<p>
+				{{duration.years()}} years, {{duration.months()}} months, {{duration.days()}} days, {{duration.hours()}} hours, {{duration.minutes()}} minutes, {{duration.seconds()}} seconds
+			</p>
             <p>
-                {{ duration }}
+                <label>ISO-8601 duration:</label>&nbsp;{{ duration }}
             </p>
-        </div>
+        </div>		
+		<hr>
+		<h1>Example Using MaxUnit</h1>
+		<div data-ng-controller="TimepickerCtrl">
+			<p>
+				The hours textbox has the max-unit attribute, which allows it to exceed the default max of 59. Without this attribute,
+				the hours textbox can't be larger than 59 because the control implicitly assumes you will also have a days textbox.
+				With this attribute in use, hours are unbounded and can grow to any value.
+			</p>
+			<p>
+				In this example, hours has a maximum value of 100, which means:
+				<ul>
+					<li>Seconds and minutes are capped to their default maximum values (59)</li>
+					<li>Hours are capped to a maximum of 100 hours, and are able to have a value on the interval [24,99] because the max-unit attribute is present.</li>
+					<li>The control in this form has a maximum supported value of 100 hours, 59 minutes, and 59 seconds.</li>
+				</ul>
+			</p>
+			<p>It generally makes no sense to apply the max-unit attribute to any input except the largest unit of time your page will support.</p>
+            <p>
+                <label>Hours:</label>&nbsp;<input data-momentduration="hours" data-max-unit max="100" data-ng-model="duration"/>
+                <label>Minutes:</label>&nbsp;<input data-momentduration="minutes" data-ng-model="duration"/>
+                <label>Seconds:</label>&nbsp;<input data-momentduration="seconds" data-ng-model="duration"/>
+            </p>
+			<p>
+				{{duration.asHours() | floor}} hours, {{duration.minutes()}} minutes, {{duration.seconds()}} seconds
+			</p>
+            <p>
+                <label>ISO-8601 duration:</label>&nbsp;{{ duration }}
+            </p>
+		</div>
+		<a href="https://github.com/Recras/angular-moment-duration">angular-moment-duration Project Home</a>
 
         <script type="text/javascript" src="../bower_components/moment/min/moment.min.js"></script>
         <script type="text/javascript" src="../bower_components/angular/angular.js"></script>

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -4,7 +4,12 @@ app.controller('TimepickerCtrl', function ($scope) {
     $scope.duration = moment.duration({
         seconds: 30,
         minutes: 45,
-        hours: 4,
-        days: 70,
+        hours: 14,
+        days: 2,
     });
+})
+.filter('floor', function(){
+	return function(input){
+		return Math.floor(input);
+	};
 });

--- a/src/angular-moment-duration.js
+++ b/src/angular-moment-duration.js
@@ -5,7 +5,7 @@
  */
 angular.module('ui.moment-duration', [])
 
-.directive('momentduration', [function() {
+.directive('momentduration', [function () {
     return {
         restrict: 'A',
         require: 'ngModel',
@@ -14,7 +14,7 @@ angular.module('ui.moment-duration', [])
             type: '@momentduration',
             maxUnit: '@maxUnit'
         },
-        link: function(scope, element, attrs, ngModel) {
+        link: function (scope, element, attrs, ngModel) {
             ngModel.$render = function () {
                 if (!ngModel.$modelValue) {
                     return;
@@ -28,12 +28,18 @@ angular.module('ui.moment-duration', [])
                 else {
                     value = duration.as(scope.type);
                 }
+
+                if (attrs.min === undefined) {
+                    attrs.$set('min', '0');
+                }
+                if (attrs.type === undefined) {
+                    attrs.$set('type', 'number');
+                }
                 element.val(Math.floor(value));
             };
 
-
-            ngModel.$parsers.unshift(function(viewValue){
-				var duration = ngModel.$modelValue;
+            ngModel.$parsers.unshift(function (viewValue) {
+                var duration = ngModel.$modelValue;
                 var newValue;
                 if (scope.maxUnit === undefined) {
                     newValue = duration.get(scope.type);

--- a/src/angular-moment-duration.js
+++ b/src/angular-moment-duration.js
@@ -71,10 +71,7 @@ angular.module('ui.moment-duration', [])
                 else {
                     newValue = Math.floor(duration.as(scope.type));
                 }
-                var diff = moment.duration(viewValue - newValue, scope.type);
-                duration.add(diff);
-				// temporary workaround for a moment bug: https://github.com/moment/moment/issues/2166
-                return moment.duration(duration.asMilliseconds());
+                return duration.add(moment.duration(viewValue - newValue, scope.type));
             });
         }
     };

--- a/src/angular-moment-duration.js
+++ b/src/angular-moment-duration.js
@@ -76,7 +76,7 @@ angular.module('ui.moment-duration', [])
                         break;
                 }
                 duration.add(diff);
-                return duration;
+                return moment.duration(duration);
             });
         }
     };

--- a/src/angular-moment-duration.js
+++ b/src/angular-moment-duration.js
@@ -29,12 +29,36 @@ angular.module('ui.moment-duration', [])
                     value = duration.as(scope.type);
                 }
 
-                if (attrs.min === undefined) {
-                    attrs.$set('min', '0');
-                }
                 if (attrs.type === undefined) {
                     attrs.$set('type', 'number');
                 }
+
+                if (attrs.min === undefined) {
+                    attrs.$set('min', '0');
+                }
+
+                if (attrs.max === undefined) {
+                    var maxVal;
+                    switch (scope.type) {
+                        case 'seconds':
+                        case 'minutes':
+                            maxVal = 59;
+                            break;
+                        case 'hours':
+                            maxVal = 23;
+                            break;
+                        case 'days':
+                            maxVal = 29; // 30 days == 1 month in moment
+                            break;
+                        case 'months':
+                            maxVal = 11;
+                            break;
+                    }
+                    if (maxVal) {
+                        attrs.$set('max', maxVal);
+                    }
+                }
+
                 element.val(Math.floor(value));
             };
 

--- a/src/angular-moment-duration.js
+++ b/src/angular-moment-duration.js
@@ -73,7 +73,8 @@ angular.module('ui.moment-duration', [])
                 }
                 var diff = moment.duration(viewValue - newValue, scope.type);
                 duration.add(diff);
-                return moment.duration(duration);
+				// temporary workaround for a moment bug: https://github.com/moment/moment/issues/2166
+                return moment.duration(duration.asMilliseconds());
             });
         }
     };

--- a/src/angular-moment-duration.js
+++ b/src/angular-moment-duration.js
@@ -11,70 +11,37 @@ angular.module('ui.moment-duration', [])
         require: 'ngModel',
         priority: 1,
         scope: {
-            type: '@momentduration'
+            type: '@momentduration',
+            maxUnit: '@maxUnit'
         },
         link: function(scope, element, attrs, ngModel) {
             ngModel.$render = function () {
-                var duration = ngModel.$modelValue;
-                if (!duration) {
+                if (!ngModel.$modelValue) {
                     return;
                 }
-                attrs.$set('type', 'number');
-                attrs.$set('min', '0');
+                var duration = moment.duration(ngModel.$modelValue);
 
                 var value;
-                switch (scope.type) {
-                    case 'years':
-                        value = Math.floor(duration.years());
-                        break;
-                    case 'months':
-                        value = Math.floor(duration.months());
-                        attrs.$set('max', '11');
-                        break;
-                    case 'days':
-                        value = Math.floor(duration.days());
-                        attrs.$set('max', '29');
-                        break;
-                    case 'hours':
-                        value = Math.floor(duration.hours());
-                        attrs.$set('max', '23');
-                        break;
-                    case 'minutes':
-                        value = Math.floor(duration.minutes());
-                        attrs.$set('max', '59');
-                        break;
-                    case 'seconds':
-                        value = Math.floor(duration.seconds());
-                        attrs.$set('max', '59');
-                        break;
+                if (attrs.maxUnit === undefined) {
+                    value = duration.get(scope.type);
                 }
-                element.val(value);
+                else {
+                    value = duration.as(scope.type);
+                }
+                element.val(Math.floor(value));
             };
 
 
             ngModel.$parsers.unshift(function(viewValue){
-                var duration = ngModel.$modelValue;
-                var diff;
-                switch (scope.type) {
-                    case 'years':
-                        diff = moment.duration(viewValue - duration.years(), 'years');
-                        break;
-                    case 'months':
-                        diff = moment.duration(viewValue - duration.months(), 'months');
-                        break;
-                    case 'days':
-                        diff = moment.duration(viewValue - duration.days(), 'days');
-                        break;
-                    case 'hours':
-                        diff = moment.duration(viewValue - duration.hours(), 'hours');
-                        break;
-                    case 'minutes':
-                        diff = moment.duration(viewValue - duration.minutes(), 'minutes');
-                        break;
-                    case 'seconds':
-                        diff = moment.duration(viewValue - duration.seconds(), 'seconds');
-                        break;
+				var duration = ngModel.$modelValue;
+                var newValue;
+                if (scope.maxUnit === undefined) {
+                    newValue = duration.get(scope.type);
                 }
+                else {
+                    newValue = Math.floor(duration.as(scope.type));
+                }
+                var diff = moment.duration(viewValue - newValue, scope.type);
                 duration.add(diff);
                 return moment.duration(duration);
             });


### PR DESCRIPTION
Hi,

I had a specific use case that I was able to implement into angular-moment-duration without causing any destructive changes. You're welcome to use this PR if it matches your vision for the directive.

Specific changes:
* Added a max-unit property, allowing developers to define the largest unit they intend to use.

This is useful, for example, if you want to collect a duration in days, hours, and minutes, and want to allow more than 30 days. Moment.duration represents 30 days as 1 month, originally causing the day value to disappear if there was no month input. It now treats the unit decorated with max-unit as unbounded, by using moment.duration.asDays() instead of moment.duration.days(), etc.

* Directive no longer sets the input type, min, or max if they have already been set

* Used a more concise moment.duration API for getting/setting the duration value

* Added content to the demo to show the new functionality

* Unshift() now returns a new duration. Please see commit #ebed8512996a582b5f1434767993b0ca4f912d5f - I don't completely understand why this is necessary, but in my attempts to $watch the duration value in my application (from a parent controller), this was necessary for the watch event to fire when the duration value changed.