### PR TITLE
Parse ngModel.$modelValue to Duration object

### DIFF
--- a/src/angular-moment-duration.js
+++ b/src/angular-moment-duration.js
@@ -62,10 +62,7 @@ angular.module('ui.moment-duration', [])
                 };
 
                 ngModel.$parsers.unshift(function(viewValue) {
-                    var duration = ngModel.$modelValue;
-                    if (!duration) {
-                        duration = moment.duration();
-                    }
+                    var duration = moment.duration(ngModel.$modelValue);
                     var newValue;
                     if (scope.maxUnit === undefined) {
                         newValue = duration.get(scope.type);


### PR DESCRIPTION
If I set the ng-model to a valid Duration object and then try to change/update the ng-model through this directive, I get the error "TypeError: duration.get is not a function (angular-moment-duration.js:71). ngModel.$modelValue seems to be a String, not a Duration object. This PR makes Moment.js parse the $modelValue to a valid Duration object, which fixes the issue for me.