### PR TITLE
Set attributes even if no value is present

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-moment-duration",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "homepage": "https://github.com/Recras/angular-moment-duration",
   "description": "An AngularJS directive for moment.js duration",
   "main": "./src/angular-moment-duration.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-moment-duration",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "An AngularJS directive for moment.js duration",
   "main": "src/angular-moment-duration.js",
   "scripts": {

--- a/src/angular-moment-duration.js
+++ b/src/angular-moment-duration.js
@@ -16,18 +16,6 @@ angular.module('ui.moment-duration', [])
             },
             link: function(scope, element, attrs, ngModel) {
                 ngModel.$render = function() {
-                    if (!ngModel.$modelValue) {
-                        return;
-                    }
-                    var duration = moment.duration(ngModel.$modelValue);
-
-                    var value;
-                    if (attrs.maxUnit === undefined) {
-                        value = duration.get(scope.type);
-                    } else {
-                        value = duration.as(scope.type);
-                    }
-
                     if (attrs.type === undefined) {
                         attrs.$set('type', 'number');
                     }
@@ -56,6 +44,18 @@ angular.module('ui.moment-duration', [])
                         if (maxVal) {
                             attrs.$set('max', maxVal);
                         }
+                    }
+
+                    if (!ngModel.$modelValue) {
+                        return;
+                    }
+                    var duration = moment.duration(ngModel.$modelValue);
+
+                    var value;
+                    if (attrs.maxUnit === undefined) {
+                        value = duration.get(scope.type);
+                    } else {
+                        value = duration.as(scope.type);
                     }
 
                     element.val(Math.floor(value));


### PR DESCRIPTION
When an element has no (model) value, attributes such as input type, min, and max were not set. This commit orders the code differently so they are being set properly.